### PR TITLE
Add connection status notification

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -4,7 +4,10 @@
     android:installLocation="internalOnly">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission
         android:name="android.permission.SYSTEM_ALERT_WINDOW"
@@ -123,6 +126,14 @@
                 <action android:name="org.amnezia.awg.action.SET_TUNNEL_DOWN" />
             </intent-filter>
         </receiver>
+        <receiver
+            android:name=".DisconnectTunnelsReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="org.amnezia.awg.action.SET_ALL_TUNNELS_DOWN" />
+            </intent-filter>
+        </receiver>
 
         <service
             android:name=".QuickTileService"
@@ -141,6 +152,12 @@
             <meta-data
                 android:name="android.service.quicksettings.TOGGLEABLE_TILE"
                 android:value="true" />
+        </service>
+
+        <service
+            android:name=".ConnectionStatusService"
+            android:foregroundServiceType="specialUse">
+            <meta-data android:name="android.app.background_running" android:value="true" />
         </service>
 
         <meta-data

--- a/ui/src/main/java/org/amnezia/awg/ConnectionStatusService.kt
+++ b/ui/src/main/java/org/amnezia/awg/ConnectionStatusService.kt
@@ -1,0 +1,209 @@
+package org.amnezia.awg
+
+import android.Manifest
+import android.app.ForegroundServiceStartNotAllowedException
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.ServiceCompat
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.amnezia.awg.activity.MainActivity
+import org.amnezia.awg.backend.Statistics
+import org.amnezia.awg.backend.Tunnel
+import org.amnezia.awg.config.Config
+import org.amnezia.awg.model.ObservableTunnel
+import org.amnezia.awg.util.QuantityFormatter
+import org.amnezia.awg.util.applicationScope
+
+class ConnectionStatusService : Service() {
+    private var isUpdateActive = true
+
+    override fun onBind(intent: Intent): IBinder? {
+        return null
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val channel = NotificationChannelCompat.Builder(CONNECTION_STATUS_NOTIFICATION_CHANNEL_ID, NotificationManager.IMPORTANCE_DEFAULT)
+            .setName(getString(R.string.notification_channel_name))
+            .setShowBadge(false)
+            .build()
+        NotificationManagerCompat.from(this).createNotificationChannel(channel)
+    }
+
+    override fun onDestroy() {
+        showDisconnectingNotification()
+        isUpdateActive = false
+        super.onDestroy()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground()
+
+        applicationScope.launch {
+            while (isUpdateActive) {
+                updateConnectionStatus()
+                delay(1000)
+            }
+        }
+
+        return START_STICKY
+    }
+
+    private fun createContentIntent(): PendingIntent {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            action = Intent.ACTION_MAIN
+            addCategory(Intent.CATEGORY_LAUNCHER)
+        }
+        return PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+    }
+
+    private fun createActionIntent(): PendingIntent {
+        val intent = Intent(this, DisconnectTunnelsReceiver::class.java).apply {
+            action = "org.amnezia.awg.action.SET_ALL_TUNNELS_DOWN"
+            putExtra(NotificationCompat.EXTRA_NOTIFICATION_ID, FOREGROUND_NOTIFICATION_ID)
+        }
+        return PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+    }
+
+    private fun createOneTunnelNotification(tunnel: Tunnel, config: Config, statistics: Statistics): Notification {
+        var contextText: String
+        if (config.peers.size == 1) {
+            val peerStats = statistics.peer(config.peers.first().publicKey)
+            val rxBytes = QuantityFormatter.formatBytes(peerStats?.rxBytes() ?: 0)
+            val txBytes = QuantityFormatter.formatBytes(peerStats?.txBytes() ?: 0)
+            contextText = getString(R.string.notification_text_rx_tx, rxBytes, txBytes)
+        } else {
+            contextText = getString(R.string.notification_text_peers_count, config.peers.size)
+        }
+        val builder = NotificationCompat.Builder(this, CONNECTION_STATUS_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_icon)
+            .setContentTitle(getString(R.string.notification_title_connected_to, tunnel.name))
+            .setContentText(contextText)
+            .setOngoing(true)
+            .setSilent(true)
+            .setContentIntent(createContentIntent())
+            .addAction(0, getString(R.string.notification_action_disconnect), createActionIntent())
+        return builder.build()
+    }
+
+    private fun createMultipleTunnelNotification(tunnels: MutableList<ObservableTunnel>): Notification {
+        val builder = NotificationCompat.Builder(this, CONNECTION_STATUS_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_icon)
+            .setContentTitle(getString(R.string.notification_title_connected))
+            .setContentText(getString(R.string.notification_text_tunnels_count, tunnels.size))
+            .setOngoing(true)
+            .setSilent(true)
+            .setContentIntent(createContentIntent())
+            .addAction(0, getString(R.string.notification_action_disconnect), createActionIntent())
+        return builder.build()
+    }
+
+    private fun createConnectingNotification(): Notification {
+        val builder = NotificationCompat.Builder(this, CONNECTION_STATUS_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_icon)
+            .setContentTitle(getString(R.string.notification_title_connecting))
+            .setOngoing(true)
+            .setSilent(true)
+            .setContentIntent(createContentIntent())
+        return builder.build()
+    }
+
+    private fun createDisconnectedNotification(): Notification {
+        val builder = NotificationCompat.Builder(this, CONNECTION_STATUS_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_icon)
+            .setContentTitle(getString(R.string.notification_title_disconnected))
+            .setOngoing(true)
+            .setSilent(true)
+            .setContentIntent(createContentIntent())
+        return builder.build()
+    }
+
+    private fun showNotification(notification: Notification) {
+        with(NotificationManagerCompat.from(this)) {
+            if (ActivityCompat.checkSelfPermission(
+                    this@ConnectionStatusService,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                return@with
+            }
+
+            notify(FOREGROUND_NOTIFICATION_ID, notification)
+        }
+    }
+
+    private suspend fun updateConnectionStatus() {
+        val manager = Application.getTunnelManager()
+        val activeTunnels = mutableListOf<ObservableTunnel>()
+        manager.getTunnels().forEach {
+            if (it.state == Tunnel.State.UP) {
+                activeTunnels.add(it)
+            }
+        }
+
+        var notification: Notification
+        if (activeTunnels.size == 1) {
+            val tunnel = activeTunnels.first()
+            val statistics = manager.getTunnelStatistics(tunnel)
+            val config = manager.getTunnelConfig(tunnel)
+            notification = createOneTunnelNotification(tunnel, config, statistics)
+        } else if (activeTunnels.size > 1) {
+            notification = createMultipleTunnelNotification(activeTunnels)
+        } else {
+            notification = createDisconnectedNotification()
+        }
+
+        showNotification(notification)
+    }
+
+    private fun showDisconnectingNotification() {
+        val builder = NotificationCompat.Builder(this, CONNECTION_STATUS_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_icon)
+            .setContentTitle(getString(R.string.notification_title_disconnecting))
+            .setTimeoutAfter(500)
+            .setSilent(true)
+            .setContentIntent(createContentIntent())
+        showNotification(builder.build())
+    }
+
+    private fun startForeground() {
+        try {
+            ServiceCompat.startForeground(
+                this,
+                FOREGROUND_NOTIFICATION_ID,
+                createConnectingNotification(),
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+                } else {
+                    0
+                }
+            )
+        } catch (e: Exception) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                && e is ForegroundServiceStartNotAllowedException
+            ) {
+                Log.e(TAG, "Failed to start foreground service", e)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "AmneziaWG/ConnectionStatusService"
+        private const val CONNECTION_STATUS_NOTIFICATION_CHANNEL_ID: String = "connection_status"
+        private const val FOREGROUND_NOTIFICATION_ID = 1
+    }
+}

--- a/ui/src/main/java/org/amnezia/awg/DisconnectTunnelsReceiver.kt
+++ b/ui/src/main/java/org/amnezia/awg/DisconnectTunnelsReceiver.kt
@@ -1,0 +1,34 @@
+package org.amnezia.awg
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import android.widget.Toast
+import kotlinx.coroutines.launch
+import org.amnezia.awg.backend.Tunnel
+import org.amnezia.awg.util.ErrorMessages
+import org.amnezia.awg.util.applicationScope
+
+class DisconnectTunnelsReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action ?: return
+        if ("org.amnezia.awg.action.SET_ALL_TUNNELS_DOWN" != action) return
+
+        applicationScope.launch {
+            val manager = Application.getTunnelManager()
+            manager.getTunnels().forEach {
+                try {
+                    manager.setTunnelState(it, Tunnel.State.DOWN)
+                } catch (e: Throwable) {
+                    Toast.makeText(context, ErrorMessages[e], Toast.LENGTH_LONG).show()
+                    Log.e(TAG, ErrorMessages[e], e)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "AmneziaWG/DisconnectTunnelReceiver"
+    }
+}

--- a/ui/src/main/java/org/amnezia/awg/util/UserKnobs.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/UserKnobs.kt
@@ -53,6 +53,12 @@ object UserKnobs {
             it[ALLOW_REMOTE_CONTROL_INTENTS] ?: false
         }
 
+    private val ENABLE_NOTIFICATION = booleanPreferencesKey("enable_notification")
+    val enableNotification: Flow<Boolean>
+        get() = Application.getPreferencesDataStore().data.map {
+            it[ENABLE_NOTIFICATION] ?: false
+        }
+
     private val RESTORE_ON_BOOT = booleanPreferencesKey("restore_on_boot")
     val restoreOnBoot: Flow<Boolean>
         get() = Application.getPreferencesDataStore().data.map {

--- a/ui/src/main/res/values-ru/strings.xml
+++ b/ui/src/main/res/values-ru/strings.xml
@@ -270,4 +270,16 @@
     <string name="biometric_auth_error">Ошибка аутентификации</string>
     <string name="biometric_auth_error_reason">Ошибка аутентификации: %s</string>
     <string name="import_disclaimer">Убедитесь, что вы получили файл конфигурации в надёжном источнике.\n\nОфициальные сервисы Amnezia доступны только на сайте <a href="https://storage.googleapis.com/amnezia/amnezia.org">amnezia.org</a>\n</string>
+    <string name="notification_channel_name">Статус соединения</string>
+    <string name="notification_title_connecting">Подключение…</string>
+    <string name="notification_title_connected">Подключено</string>
+    <string name="notification_title_connected_to">Подключено к %s</string>
+    <string name="notification_title_disconnecting">Отключение…</string>
+    <string name="notification_title_disconnected">Отключено</string>
+    <string name="notification_text_tunnels_count">Количество активных туннелей: %d</string>
+    <string name="notification_text_peers_count">Количество пиров: %d</string>
+    <string name="notification_action_disconnect">Отключить</string>
+    <string name="enable_notification_title">Уведомление</string>
+    <string name="enable_notification_summary_off">Уведомление о состоянии соединения отключено</string>
+    <string name="enable_notification_summary_on">Уведомление о состоянии соединения включено</string>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -254,4 +254,17 @@
     <string name="biometric_auth_error">Authentication failure</string>
     <string name="biometric_auth_error_reason">Authentication failure: %s</string>
     <string name="import_disclaimer">Ensure that you obtained the configuration file from a trusted source.\n\nOfficial Amnezia services are available only at <a href="https://amnezia.org">amnezia.org</a>\n</string>
+    <string name="notification_channel_name">Connection status</string>
+    <string name="notification_title_connecting">Connecting…</string>
+    <string name="notification_title_connected">Connected</string>
+    <string name="notification_title_connected_to">Connected to %s</string>
+    <string name="notification_title_disconnecting">Disconnecting…</string>
+    <string name="notification_title_disconnected">Disconnected</string>
+    <string name="notification_text_rx_tx">%1$s↓ %2$s↑</string>
+    <string name="notification_text_tunnels_count">Active tunnels count: %d</string>
+    <string name="notification_text_peers_count">Peers count: %d</string>
+    <string name="notification_action_disconnect">Disconnect</string>
+    <string name="enable_notification_title">Notification</string>
+    <string name="enable_notification_summary_off">Connection status notification is disabled</string>
+    <string name="enable_notification_summary_on">Connection status notification is enabled</string>
 </resources>

--- a/ui/src/main/res/xml/preferences.xml
+++ b/ui/src/main/res/xml/preferences.xml
@@ -41,4 +41,11 @@
         android:summaryOff="@string/allow_remote_control_intents_summary_off"
         android:summaryOn="@string/allow_remote_control_intents_summary_on"
         android:title="@string/allow_remote_control_intents_title" />
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="enable_notification"
+        android:singleLineTitle="false"
+        android:summaryOff="@string/enable_notification_summary_off"
+        android:summaryOn="@string/enable_notification_summary_on"
+        android:title="@string/enable_notification_title" />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Added notification that shows the current connection status: which tunnel is connected, the number of bytes received and transmitted, etc. You can use the notification to disconnect all active tunnels. The notification can be disabled in the app settings.