### PR TITLE
Add "Prefer IPv6" option for endpoint resolution

### DIFF
--- a/tunnel/src/main/java/org/amnezia/awg/backend/GoBackend.java
+++ b/tunnel/src/main/java/org/amnezia/awg/backend/GoBackend.java
@@ -351,13 +351,14 @@ public final class GoBackend implements Backend {
             }
 
 
+            final boolean preferIpv6 = config.getInterface().getPreferIpv6().orElse(false);
             dnsRetry: for (int i = 0; i < DNS_RESOLUTION_RETRIES; ++i) {
                 // Pre-resolve IPs so they're cached when building the userspace string
                 for (final Peer peer : config.getPeers()) {
                     final InetEndpoint ep = peer.getEndpoint().orElse(null);
                     if (ep == null)
                         continue;
-                    if (ep.getResolved().orElse(null) == null) {
+                    if (ep.getResolved(preferIpv6).orElse(null) == null) {
                         if (i < DNS_RESOLUTION_RETRIES - 1) {
                             Log.w(TAG, "DNS host \"" + ep.getHost() + "\" failed to resolve; trying again");
                             Thread.sleep(1000);

--- a/tunnel/src/main/java/org/amnezia/awg/config/BadConfigException.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/BadConfigException.java
@@ -75,6 +75,7 @@ public class BadConfigException extends Exception {
         INCLUDED_APPLICATIONS("IncludedApplications"),
         LISTEN_PORT("ListenPort"),
         MTU("MTU"),
+        PREFER_IPV6("PreferIpv6"),
         PERSISTENT_KEEPALIVE("PersistentKeepalive"),
         PRE_SHARED_KEY("PresharedKey"),
         PRIVATE_KEY("PrivateKey"),

--- a/tunnel/src/main/java/org/amnezia/awg/config/Config.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/Config.java
@@ -177,8 +177,9 @@ public final class Config {
         final StringBuilder sb = new StringBuilder();
         sb.append(interfaze.toAwgUserspaceString());
         sb.append("replace_peers=true\n");
+        final boolean preferIpv6 = interfaze.getPreferIpv6().orElse(false);
         for (final Peer peer : peers)
-            sb.append(peer.toAwgUserspaceString());
+            sb.append(peer.toAwgUserspaceString(preferIpv6));
         return sb.toString();
     }
 

--- a/tunnel/src/main/java/org/amnezia/awg/config/InetEndpoint.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/InetEndpoint.java
@@ -8,6 +8,7 @@ package org.amnezia.awg.config;
 import org.amnezia.awg.util.NonNullForAll;
 
 import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -88,19 +89,38 @@ public final class InetEndpoint {
      * @return the resolved endpoint, or {@link Optional#empty()}
      */
     public Optional<InetEndpoint> getResolved() {
+        return getResolved(false);
+    }
+
+    /**
+     * Generate an {@code InetEndpoint} instance with the same port and the host resolved using DNS
+     * to a numeric address. If the host is already numeric, the existing instance may be returned.
+     * Because this function may perform network I/O, it must not be called from the main thread.
+     *
+     * @param preferIpv6 when true, prefer IPv6 addresses; when false, prefer IPv4 addresses
+     * @return the resolved endpoint, or {@link Optional#empty()}
+     */
+    public Optional<InetEndpoint> getResolved(final boolean preferIpv6) {
         if (isResolved)
             return Optional.of(this);
         synchronized (lock) {
             //TODO(zx2c4): Implement a real timeout mechanism using DNS TTL
             if (Duration.between(lastResolution, Instant.now()).toMinutes() > 1) {
                 try {
-                    // Prefer v4 endpoints over v6 to work around DNS64 and IPv6 NAT issues.
                     final InetAddress[] candidates = InetAddress.getAllByName(host);
                     InetAddress address = candidates[0];
                     for (final InetAddress candidate : candidates) {
-                        if (candidate instanceof Inet4Address) {
-                            address = candidate;
-                            break;
+                        if (preferIpv6) {
+                            if (candidate instanceof Inet6Address) {
+                                address = candidate;
+                                break;
+                            }
+                        } else {
+                            // Prefer v4 endpoints over v6 to work around DNS64 and IPv6 NAT issues.
+                            if (candidate instanceof Inet4Address) {
+                                address = candidate;
+                                break;
+                            }
                         }
                     }
                     resolved = new InetEndpoint(address.getHostAddress(), true, port);

--- a/tunnel/src/main/java/org/amnezia/awg/config/Interface.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/Interface.java
@@ -62,6 +62,7 @@ public final class Interface {
     private final Optional<String> specialJunkI3;
     private final Optional<String> specialJunkI4;
     private final Optional<String> specialJunkI5;
+    private final Optional<Boolean> preferIpv6;
 
     private Interface(final Builder builder) {
         // Defensively copy to ensure immutability even if the Builder is reused.
@@ -89,6 +90,7 @@ public final class Interface {
         specialJunkI3 = builder.specialJunkI3;
         specialJunkI4 = builder.specialJunkI4;
         specialJunkI5 = builder.specialJunkI5;
+        preferIpv6 = builder.preferIpv6;
     }
 
     /**
@@ -123,6 +125,9 @@ public final class Interface {
                     break;
                 case "mtu":
                     builder.parseMtu(attribute.getValue());
+                    break;
+                case "preferipv6":
+                    builder.parsePreferIpv6(attribute.getValue());
                     break;
                 case "privatekey":
                     builder.parsePrivateKey(attribute.getValue());
@@ -211,7 +216,8 @@ public final class Interface {
                 && specialJunkI2.equals(other.specialJunkI2)
                 && specialJunkI3.equals(other.specialJunkI3)
                 && specialJunkI4.equals(other.specialJunkI4)
-                && specialJunkI5.equals(other.specialJunkI5);
+                && specialJunkI5.equals(other.specialJunkI5)
+                && preferIpv6.equals(other.preferIpv6);
     }
 
     /**
@@ -435,6 +441,14 @@ public final class Interface {
         return specialJunkI5;
     }
 
+    /**
+     * Returns whether IPv6 is preferred for endpoint resolution.
+     *
+     * @return the preferIpv6 flag, or {@code Optional.empty()} if none is configured
+     */
+    public Optional<Boolean> getPreferIpv6() {
+        return preferIpv6;
+    }
 
     @Override
     public int hashCode() {
@@ -462,6 +476,7 @@ public final class Interface {
         hash = 31 * hash + specialJunkI3.hashCode();
         hash = 31 * hash + specialJunkI4.hashCode();
         hash = 31 * hash + specialJunkI5.hashCode();
+        hash = 31 * hash + preferIpv6.hashCode();
         return hash;
     }
 
@@ -501,6 +516,7 @@ public final class Interface {
             sb.append("IncludedApplications = ").append(Attribute.join(includedApplications)).append('\n');
         listenPort.ifPresent(lp -> sb.append("ListenPort = ").append(lp).append('\n'));
         mtu.ifPresent(m -> sb.append("MTU = ").append(m).append('\n'));
+        preferIpv6.ifPresent(v -> sb.append("PreferIpv6 = ").append(v).append('\n'));
         junkPacketCount.ifPresent(jc -> sb.append("Jc = ").append(jc).append('\n'));
         junkPacketMinSize.ifPresent(jmin -> sb.append("Jmin = ").append(jmin).append('\n'));
         junkPacketMaxSize.ifPresent(jmax -> sb.append("Jmax = ").append(jmax).append('\n'));
@@ -600,6 +616,8 @@ public final class Interface {
         private Optional<String> specialJunkI4 = Optional.empty();
         // Defaults to not present.
         private Optional<String> specialJunkI5 = Optional.empty();
+        // Defaults to not present.
+        private Optional<Boolean> preferIpv6 = Optional.empty();
 
 
         public Builder addAddress(final InetNetwork address) {
@@ -711,6 +729,23 @@ public final class Interface {
             } catch (final NumberFormatException e) {
                 throw new BadConfigException(Section.INTERFACE, Location.MTU, mtu, e);
             }
+        }
+
+        public Builder parsePreferIpv6(final String preferIpv6) throws BadConfigException {
+            switch (preferIpv6.toLowerCase(Locale.ENGLISH)) {
+                case "true":
+                    return setPreferIpv6(true);
+                case "false":
+                    return setPreferIpv6(false);
+                default:
+                    throw new BadConfigException(Section.INTERFACE, Location.PREFER_IPV6,
+                            Reason.INVALID_VALUE, preferIpv6);
+            }
+        }
+
+        public Builder setPreferIpv6(final boolean preferIpv6) {
+            this.preferIpv6 = Optional.of(preferIpv6);
+            return this;
         }
 
         public Builder parseJunkPacketCount(final String junkPacketCount) throws BadConfigException {

--- a/tunnel/src/main/java/org/amnezia/awg/config/Peer.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/Peer.java
@@ -191,12 +191,23 @@ public final class Peer {
      * @return the {@code Peer} represented as a series of "key=value" lines
      */
     public String toAwgUserspaceString() {
+        return toAwgUserspaceString(false);
+    }
+
+    /**
+     * Serializes the {@code Peer} for use with the AmneziaWG cross-platform userspace API. Note
+     * that not all attributes are included in this representation.
+     *
+     * @param preferIpv6 when true, prefer IPv6 addresses for endpoint resolution
+     * @return the {@code Peer} represented as a series of "key=value" lines
+     */
+    public String toAwgUserspaceString(final boolean preferIpv6) {
         final StringBuilder sb = new StringBuilder();
         // The order here is important: public_key signifies the beginning of a new peer.
         sb.append("public_key=").append(publicKey.toHex()).append('\n');
         for (final InetNetwork allowedIp : allowedIps)
             sb.append("allowed_ip=").append(allowedIp).append('\n');
-        endpoint.flatMap(InetEndpoint::getResolved).ifPresent(ep -> sb.append("endpoint=").append(ep).append('\n'));
+        endpoint.flatMap(ep -> ep.getResolved(preferIpv6)).ifPresent(ep -> sb.append("endpoint=").append(ep).append('\n'));
         persistentKeepalive.ifPresent(pk -> sb.append("persistent_keepalive_interval=").append(pk).append('\n'));
         preSharedKey.ifPresent(psk -> sb.append("preshared_key=").append(psk.toHex()).append('\n'));
         return sb.toString();

--- a/ui/src/main/java/org/amnezia/awg/viewmodel/InterfaceProxy.kt
+++ b/ui/src/main/java/org/amnezia/awg/viewmodel/InterfaceProxy.kt
@@ -166,6 +166,13 @@ class InterfaceProxy : BaseObservable, Parcelable {
         }
 
     @get:Bindable
+    var preferIpv6: Boolean = false
+        set(value) {
+            field = value
+            notifyPropertyChanged(BR.preferIpv6)
+        }
+
+    @get:Bindable
     var privateKey: String = ""
         set(value) {
             field = value
@@ -205,6 +212,7 @@ class InterfaceProxy : BaseObservable, Parcelable {
         specialJunkI4 = parcel.readString() ?: ""
         specialJunkI5 = parcel.readString() ?: ""
         privateKey = parcel.readString() ?: ""
+        preferIpv6 = parcel.readInt() != 0
     }
 
     constructor(other: Interface) {
@@ -231,6 +239,7 @@ class InterfaceProxy : BaseObservable, Parcelable {
         specialJunkI3 = other.specialJunkI3.orElse("")
         specialJunkI4 = other.specialJunkI4.orElse("")
         specialJunkI5 = other.specialJunkI5.orElse("")
+        preferIpv6 = other.preferIpv6.orElse(false)
         val keyPair = other.keyPair
         privateKey = keyPair.privateKey.toBase64()
     }
@@ -271,6 +280,7 @@ class InterfaceProxy : BaseObservable, Parcelable {
         if (specialJunkI3.isNotEmpty()) builder.parseSpecialJunkI3(specialJunkI3)
         if (specialJunkI4.isNotEmpty()) builder.parseSpecialJunkI4(specialJunkI4)
         if (specialJunkI5.isNotEmpty()) builder.parseSpecialJunkI5(specialJunkI5)
+        if (preferIpv6) builder.setPreferIpv6(true)
         if (privateKey.isNotEmpty()) builder.parsePrivateKey(privateKey)
         return builder.build()
     }
@@ -299,6 +309,7 @@ class InterfaceProxy : BaseObservable, Parcelable {
         dest.writeString(specialJunkI4)
         dest.writeString(specialJunkI5)
         dest.writeString(privateKey)
+        dest.writeInt(if (preferIpv6) 1 else 0)
     }
 
     private class InterfaceProxyCreator : Parcelable.Creator<InterfaceProxy> {

--- a/ui/src/main/res/layout/tunnel_editor_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_editor_fragment.xml
@@ -241,6 +241,18 @@
                                 android:textAlignment="center" />
                         </com.google.android.material.textfield.TextInputLayout>
 
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/prefer_ipv6_switch"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="4dp"
+                            android:padding="4dp"
+                            android:text="@string/prefer_ipv6"
+                            android:checked="@={config.interface.preferIpv6}"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/dns_servers_label_layout" />
+
                         <com.google.android.material.textfield.TextInputLayout
                             android:id="@+id/junk_packet_count_layout"
                             android:layout_width="0dp"
@@ -249,7 +261,7 @@
                             android:hint="@string/junk_packet_count"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/dns_servers_label_layout">
+                            app:layout_constraintTop_toBottomOf="@id/prefer_ipv6_switch">
 
                             <com.google.android.material.textfield.TextInputEditText
                                 android:id="@+id/junk_packet_count_text"

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="module_installer_working">Downloading and installing…</string>
     <string name="module_version_error">Unable to determine kernel module version</string>
     <string name="mtu">MTU</string>
+    <string name="prefer_ipv6">Prefer IPv6 for endpoint resolution</string>
     <string name="junk_packet_count">Junk packet count</string>
     <string name="junk_packet_min_size">Junk packet minimum size</string>
     <string name="junk_packet_max_size">Junk packet maximum size</string>


### PR DESCRIPTION
Endpoint resolution currently always prefers IPv4. This makes it impossible to use hostnames when the server is only reachable via IPv6 (e.g. behind CGNAT with no public IPv4).

This adds a `PreferIpv6 = true/false` toggle to the `[Interface]` section. When enabled, AAAA records are preferred over A records. Default behavior is unchanged.

If no IPv6 address is found, it falls back to IPv4 automatically.