### PR TITLE
feat: Allow any application to toggle the tunnels, useful for automation

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -116,8 +116,7 @@
 
         <receiver
             android:name=".model.TunnelManager$IntentReceiver"
-            android:exported="true"
-            android:permission="${applicationId}.permission.CONTROL_TUNNELS">
+            android:exported="true">
             <intent-filter>
                 <action android:name="org.amnezia.awg.action.REFRESH_TUNNEL_STATES" />
                 <action android:name="org.amnezia.awg.action.SET_TUNNEL_UP" />


### PR DESCRIPTION
I wanted to make an external app to conveniently toggle the tunnels. Useful in Russia where you need to toggle it a lot, and using the Android dropdown menu is inconvenient.  

In the current code base the external application must request CONTROL_TUNNELS permission in its manifest in order to broadcast messages to IntentReceiver.

However, there are some applications like Automate/Tasker/MacroDroid, that allow implementing simple programs without programming. Unfortunately, they don't request this permission in the manifest, thus the broadcast messages to IntentReceiver don't work. You have to actually go to Android Studio and make the app from scratch to request this permission.

So I made this change to your Android client, to remove requirement on the CONTROL_TUNNELS from the IntentReceiver.

And then I could control the tunnel from Automate. * Here I demonstrate the Automate app that I made, it's very convenient
https://github.com/user-attachments/assets/d1f0eced-acf3-4500-8533-2eabcdf2999f

Note that the user can still keep the checkbox "allow remote control intents" disabled, and so no other app by default will be able to control Amnezia client

Please consider this change, as I think it's useful, and if some external malicious application wants to disable all VPN tunnels from Amnezia, they still can do it by simply requesting this permission in the manifest. So it's a sloppy guard