### PR TITLE
tools: ship kernel tools as libawg/libawg-quick so SharedLibraryLoade…

### DIFF
--- a/tunnel/build.gradle.kts
+++ b/tunnel/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         all {
             externalNativeBuild {
                 cmake {
-                    targets("libwg-go.so", "libwg.so", "libwg-quick.so")
+                    targets("libwg-go.so", "libawg.so", "libawg-quick.so")
                     arguments("-DGRADLE_USER_HOME=${project.gradle.gradleUserHomeDir}")
                 }
             }

--- a/tunnel/tools/CMakeLists.txt
+++ b/tunnel/tools/CMakeLists.txt
@@ -10,14 +10,14 @@ add_link_options(-Wl,-z,max-page-size=16384)
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
 add_compile_options(-Wall -Werror)
 
-add_executable(libwg-quick.so amneziawg-tools/src/wg-quick/android.c ndk-compat/compat.c)
-target_compile_options(libwg-quick.so PUBLIC -std=gnu11 -include ${CMAKE_CURRENT_SOURCE_DIR}/ndk-compat/compat.h -DAWG_PACKAGE_NAME=\"${ANDROID_PACKAGE_NAME}\")
-target_link_libraries(libwg-quick.so -ldl)
+add_executable(libawg-quick.so amneziawg-tools/src/wg-quick/android.c ndk-compat/compat.c)
+target_compile_options(libawg-quick.so PUBLIC -std=gnu11 -include ${CMAKE_CURRENT_SOURCE_DIR}/ndk-compat/compat.h -DAWG_PACKAGE_NAME=\"${ANDROID_PACKAGE_NAME}\")
+target_link_libraries(libawg-quick.so -ldl)
 
 file(GLOB WG_SOURCES amneziawg-tools/src/*.c ndk-compat/compat.c)
-add_executable(libwg.so ${WG_SOURCES})
-target_include_directories(libwg.so PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/amneziawg-tools/src/uapi/linux/" "${CMAKE_CURRENT_SOURCE_DIR}/amneziawg-tools/src/")
-target_compile_options(libwg.so PUBLIC -std=gnu11 -include ${CMAKE_CURRENT_SOURCE_DIR}/ndk-compat/compat.h -DRUNSTATEDIR=\"/data/data/${ANDROID_PACKAGE_NAME}/cache\")
+add_executable(libawg.so ${WG_SOURCES})
+target_include_directories(libawg.so PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/amneziawg-tools/src/uapi/linux/" "${CMAKE_CURRENT_SOURCE_DIR}/amneziawg-tools/src/")
+target_compile_options(libawg.so PUBLIC -std=gnu11 -include ${CMAKE_CURRENT_SOURCE_DIR}/ndk-compat/compat.h -DRUNSTATEDIR=\"/data/data/${ANDROID_PACKAGE_NAME}/cache\")
 
 add_custom_target(libwg-go.so WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libwg-go" COMMENT "Building amneziawg-go" VERBATIM COMMAND "${ANDROID_HOST_PREBUILTS}/bin/make"
     ANDROID_ARCH_NAME=${ANDROID_ARCH_NAME}
@@ -38,9 +38,9 @@ add_custom_target(elf-cleaner COMMENT "Building elf-cleaner" VERBATIM COMMAND cc
         -O2 -DPACKAGE_NAME="elf-cleaner" -DPACKAGE_VERSION="" -DCOPYRIGHT=""
         -o "${CMAKE_CURRENT_BINARY_DIR}/elf-cleaner" ${ELF_CLEANER_SOURCES}
 )
-add_custom_command(TARGET libwg.so POST_BUILD VERBATIM COMMAND "${CMAKE_CURRENT_BINARY_DIR}/elf-cleaner"
-        --api-level "${ANDROID_NATIVE_API_LEVEL}" "$<TARGET_FILE:libwg.so>")
-add_dependencies(libwg.so elf-cleaner)
-add_custom_command(TARGET libwg-quick.so POST_BUILD VERBATIM COMMAND "${CMAKE_CURRENT_BINARY_DIR}/elf-cleaner"
-        --api-level "${ANDROID_NATIVE_API_LEVEL}" "$<TARGET_FILE:libwg-quick.so>")
-add_dependencies(libwg-quick.so elf-cleaner)
+add_custom_command(TARGET libawg.so POST_BUILD VERBATIM COMMAND "${CMAKE_CURRENT_BINARY_DIR}/elf-cleaner"
+        --api-level "${ANDROID_NATIVE_API_LEVEL}" "$<TARGET_FILE:libawg.so>")
+add_dependencies(libawg.so elf-cleaner)
+add_custom_command(TARGET libawg-quick.so POST_BUILD VERBATIM COMMAND "${CMAKE_CURRENT_BINARY_DIR}/elf-cleaner"
+        --api-level "${ANDROID_NATIVE_API_LEVEL}" "$<TARGET_FILE:libawg-quick.so>")
+add_dependencies(libawg-quick.so elf-cleaner)


### PR DESCRIPTION
## What

Make Android's `ToolsInstaller` find the kernel-mode tool binaries: build them as `libawg` / `libawg-quick` instead of `libwg` / `libwg-quick`, and bump the `amneziawg-tools` submodule to the kernel-first `wg-quick` fix.

## Why

`ToolsInstaller.EXECUTABLES = {"awg", "awg-quick"}` and the shared-library loader resolves them via `System.mapLibraryName()`, i.e. `libawg.so` / `libawg-quick.so` inside the APK. The CMake targets were still building `libwg.so` / `libwg-quick.so`, so the native binaries were never extracted and kernel mode failed with `FileNotFoundException` during install.

The userspace `libwg-go.so` target is kept untouched.

## Testing performed

- `./gradlew :ui:assembleRelease` — build success.
- Installed APK on device; `libawg.so`/`libawg-quick.so` extracted from APK and runtime-accessible; kernel-mode tunnel connects (requires the amneziawg kernel module).
- Verifies in combination with amnezia-vpn/amneziawg-tools fix: prefer kernel module over userspace for AWG configs.